### PR TITLE
Publish executable artifacts to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ cache:
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete
+
+script:
+   - sbt ++$TRAVIS_SCALA_VERSION ciBuild

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ changes need some adjustment before they are ready for submission.
 3. Project maintainers will squash-merge Pull Requests once they are happy.  There may be one or more
    cycles of feedback on the PR before they are satisfied.
 
+## Performing a release (for project maintainers)
+
+1. Follow the [sbt-bintray publishing guidelines](https://github.com/sbt/sbt-bintray#publishing) to ensure you are
+   authenticated with Bintray.  Note that you need to be a member of the `sky-uk` Bintray organization. 
+2. Run `sbt ciRelease` to perform the release.
+3. Check you are happy with the draft publication of the new version [here](https://bintray.com/sky-uk/oss-maven/kafka-configurator)
+   and, if so, run `sbt bintrayRelease` to make the new version publicly accessible.
+
 ## Contributor Code of Conduct
 
 As contributors and maintainers of this project, and in the interest of fostering an open and 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val dependencies = Seq(
 ) ++ kafkaDeps
 
 val root = (project in file("."))
-  .enablePlugins(BuildInfoPlugin, GitBranchPrompt, GitVersioning, JavaAppPackaging)
+  .enablePlugins(BuildInfoPlugin, GitBranchPrompt, GitVersioning, JavaAppPackaging, UniversalDeployPlugin)
   .settings(
     organization := "com.sky",
     scalaVersion := "2.12.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import Bintray._
 import BuildInfo._
 import Git._
 import Release._
@@ -34,5 +35,6 @@ val root = (project in file("."))
     fork in run := true,
     buildInfoSettings,
     gitSettings,
-    releaseSettings
+    releaseSettings,
+    bintraySettings
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import Aliases._
 import Bintray._
 import BuildInfo._
 import Git._
@@ -25,6 +26,7 @@ val dependencies = Seq(
 val root = (project in file("."))
   .enablePlugins(BuildInfoPlugin, GitBranchPrompt, GitVersioning, JavaAppPackaging, UniversalDeployPlugin)
   .settings(
+    defineCommandAliases,
     organization := "com.sky",
     scalaVersion := "2.12.1",
     name := "kafka-configurator",

--- a/project/Bintray.scala
+++ b/project/Bintray.scala
@@ -1,0 +1,13 @@
+import bintray.BintrayKeys._
+import sbt.Keys._
+import sbt.{ThisBuild, url}
+
+object Bintray {
+  lazy val bintraySettings = Seq(
+    bintrayOrganization := Some("sky-uk"),
+    bintrayReleaseOnPublish in ThisBuild := false,
+    bintrayRepository := "oss-maven",
+    bintrayVcsUrl := Some("https://github.com/sky-uk/kafka-configurator"),
+    licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
+  )
+}

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,3 +1,4 @@
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.Universal
 import sbt.Keys._
 import sbt.{Project, State, ThisBuild, taskKey}
 import sbtrelease.ReleasePlugin.autoImport._
@@ -14,6 +15,7 @@ object Release {
     releaseVersionBump := sbtrelease.Version.Bump.Minor,
     releaseTagName := s"${name.value}-${version.value}",
     releaseTagComment := s"Releasing ${version.value} of module: ${name.value}",
+    releasePublishArtifactsAction:= (publish in Universal).value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       releaseStepCommand(ExtraReleaseCommands.initialVcsChecksCommand),
@@ -21,9 +23,7 @@ object Release {
       setReleaseVersion,
       runTest,
       tagRelease,
-      // TODO: build the artifact and publish it somewhere
-      //      ReleaseStep(releaseStepTask(sbt.Keys.packageBin)),
-      //      publishArtifacts,
+      publishArtifacts,
       pushChanges
     ),
     showReleaseVersion := { val rV = releaseVersion.value.apply(version.value); println(rV); rV },

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+// We should aim to upgrade to the new version, but can't yet due to https://github.com/sbt/sbt-bintray/issues/104
+// addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")


### PR DESCRIPTION
Addresses issue #6.

This PR adds publishing the zipped binaries to Bintray as part of the release process.

You can see [here](https://bintray.com/sky-uk/oss-maven/kafka-configurator/0.8.0/view/general#files/com/sky/kafka-configurator/0.8.0) (and in the screenshot below) where I've uploaded (but not yet made openly accessible) some files using this mechanism, to prove it out.

![screen shot 2017-06-14 at 08 53 39](https://user-images.githubusercontent.com/6017680/27121383-fd6e39e2-50de-11e7-9fdf-046bb46b2721.png)

