### PR TITLE
actually inject configured properties to underlying kafka admin client

### DIFF
--- a/src/main/scala/com/sky/kafka/configurator/KafkaTopicAdmin.scala
+++ b/src/main/scala/com/sky/kafka/configurator/KafkaTopicAdmin.scala
@@ -19,7 +19,7 @@ object KafkaTopicAdmin {
 
   def reader: Reader[AppConfig, KafkaTopicAdmin] = Reader { config =>
     import com.sky.kafka.utils.MapToJavaPropertiesConversion.mapToProperties
-    KafkaTopicAdmin(AdminClient.create(Map(BOOTSTRAP_SERVERS_CONFIG -> config.bootstrapServers)))
+    KafkaTopicAdmin(AdminClient.create(Map(BOOTSTRAP_SERVERS_CONFIG -> config.bootstrapServers) ++ config.props))
   }
 }
 

--- a/src/test/scala/com/sky/kafka/configurator/KafkaTopicAdminSpec.scala
+++ b/src/test/scala/com/sky/kafka/configurator/KafkaTopicAdminSpec.scala
@@ -8,7 +8,7 @@ import common.KafkaIntSpec
 import org.scalatest.concurrent.Eventually
 import org.zalando.grafter.StopOk
 
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class KafkaTopicAdminSpec extends KafkaIntSpec with Eventually with TopicMatchers {
 
@@ -66,12 +66,12 @@ class KafkaTopicAdminSpec extends KafkaIntSpec with Eventually with TopicMatcher
   it should "fail to update with an invalid property" in {
     val inputTopic = someTopic.copy(config = Map(
       "retention.ms" -> "5000"
-      ))
+    ))
     adminClient.create(inputTopic) shouldBe Success(())
 
     val updatedTopic = inputTopic.copy(config = Map(
       "invalid.key" -> "invalid.value"
-      ))
+    ))
 
     adminClient.updateConfig(updatedTopic.name, updatedTopic.config) shouldBe a[Failure[_]]
   }
@@ -106,5 +106,10 @@ class KafkaTopicAdminSpec extends KafkaIntSpec with Eventually with TopicMatcher
       'message ("org.apache.kafka.common.errors.TimeoutException: The AdminClient thread is not accepting new calls.")
     }
 
+  }
+
+  "reader" should "pass props from config to Kafka admin client" in {
+    val overrideBootstrapServers = AppConfig().copy(props = Map("bootstrap.servers" -> s"localhost:$kafkaPort"))
+    noException shouldBe thrownBy(KafkaTopicAdmin.reader(overrideBootstrapServers))
   }
 }


### PR DESCRIPTION
Last PR added support for parsing of admin client config, but actually injecting it to the admin client was missed!

🤦‍♂️ 