### PR TITLE
Update scala-kafka-client-testkit that is no longer on Bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import BuildInfo._
 import Release._
 import Docker._
 
-val kafkaVersion = "2.3.1"
+val kafkaVersion = "2.4.1"
 
 val kafkaDeps = Seq(
   "org.apache.kafka" % "kafka-clients",
@@ -12,20 +12,19 @@ val kafkaDeps = Seq(
 ).map(_ % kafkaVersion)
 
 val dependencies = Seq(
-  "com.github.scopt"           %% "scopt"               % "3.7.1",
-  "org.zalando"                %% "grafter"             % "2.6.1",
-  "com.typesafe.scala-logging" %% "scala-logging"       % "3.5.0",
-  "io.circe"                   %% "circe-yaml"          % "0.12.0",
-  "io.circe"                   %% "circe-generic"       % "0.12.3",
-  "org.typelevel"              %% "cats-core"           % "1.5.0",
-  "org.typelevel"              %% "cats-kernel"         % "1.5.0",
-  "org.slf4j"                   % "log4j-over-slf4j"    % "1.7.25",
-  "org.slf4j"                   % "slf4j-api"           % "1.7.25",
-  "ch.qos.logback"              % "logback-classic"     % "1.2.3"   % Runtime,
-
-  "org.scalatest"              %% "scalatest"                  % "3.0.5"      % Test,
-  "net.cakesolutions"          %% "scala-kafka-client-testkit" % kafkaVersion % Test,
-  "org.mockito"                 % "mockito-all"                % "1.10.19"    % Test
+  "com.github.scopt"           %% "scopt"                      % "3.7.1",
+  "org.zalando"                %% "grafter"                    % "2.6.1",
+  "com.typesafe.scala-logging" %% "scala-logging"              % "3.5.0",
+  "io.circe"                   %% "circe-yaml"                 % "0.12.0",
+  "io.circe"                   %% "circe-generic"              % "0.12.3",
+  "org.typelevel"              %% "cats-core"                  % "1.5.0",
+  "org.typelevel"              %% "cats-kernel"                % "1.5.0",
+  "org.slf4j"                   % "log4j-over-slf4j"           % "1.7.25",
+  "org.slf4j"                   % "slf4j-api"                  % "1.7.25",
+  "ch.qos.logback"              % "logback-classic"            % "1.2.3"   % Runtime,
+  "org.scalatest"              %% "scalatest"                  % "3.0.5"   % Test,
+  "com.pirum"                  %% "scala-kafka-client-testkit" % "2.4.1-2" % Test,
+  "org.mockito"                 % "mockito-all"                % "1.10.19" % Test
 ) ++ kafkaDeps
 
 val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ val dependencies = Seq(
   "org.typelevel"              %% "cats-kernel"                % "1.5.0",
   "org.slf4j"                   % "log4j-over-slf4j"           % "1.7.25",
   "org.slf4j"                   % "slf4j-api"                  % "1.7.25",
-  "ch.qos.logback"              % "logback-classic"            % "1.2.3"   % Runtime,
-  "org.scalatest"              %% "scalatest"                  % "3.0.5"   % Test,
-  "com.pirum"                  %% "scala-kafka-client-testkit" % "2.4.1-2" % Test,
-  "org.mockito"                 % "mockito-all"                % "1.10.19" % Test
+  "ch.qos.logback"              % "logback-classic"            % "1.2.3"            % Runtime,
+  "org.scalatest"              %% "scalatest"                  % "3.0.5"            % Test,
+  "com.pirum"                  %% "scala-kafka-client-testkit" % s"$kafkaVersion-2" % Test,
+  "org.mockito"                 % "mockito-all"                % "1.10.19"          % Test
 ) ++ kafkaDeps
 
 val root = (project in file("."))

--- a/src/test/scala/com/sky/kafka/configurator/KafkaConfiguratorIntSpec.scala
+++ b/src/test/scala/com/sky/kafka/configurator/KafkaConfiguratorIntSpec.scala
@@ -16,7 +16,7 @@ class KafkaConfiguratorIntSpec extends KafkaIntSpec with Eventually {
 
     eventually {
       withClue("Topic exists: ") {
-        topics.map(kafkaAdminClient.listTopics().names().get().contains(_) shouldBe true)
+        topics.map(topicExists(_) shouldBe true)
       }
     }
   }

--- a/src/test/scala/common/KafkaIntSpec.scala
+++ b/src/test/scala/common/KafkaIntSpec.scala
@@ -1,15 +1,13 @@
 package common
 
-import cakesolutions.kafka.testkit.KafkaServer
-import kafka.utils.ZkUtils
+import com.pirum.kafka.testkit.KafkaServer
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.PatienceConfiguration
-import org.scalatest.time.{ Millis, Seconds, Span }
+import org.scalatest.time.{Millis, Seconds, Span}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration._
 
 abstract class KafkaIntSpec extends BaseSpec with BeforeAndAfterAll with PatienceConfiguration {
 
@@ -17,12 +15,6 @@ abstract class KafkaIntSpec extends BaseSpec with BeforeAndAfterAll with Patienc
 
   val kafkaServer = new KafkaServer()
   val kafkaPort = kafkaServer.kafkaPort
-
-  val zkSessionTimeout = 30 seconds
-  val zkConnectionTimeout = 30 seconds
-
-  lazy val zkUtils = ZkUtils(s"localhost:${kafkaServer.zookeeperPort}", zkSessionTimeout.toMillis.toInt,
-    zkConnectionTimeout.toMillis.toInt, isZkSecurityEnabled = false)
 
   lazy val kafkaAdminClient = AdminClient.create(Map[String, AnyRef](
     BOOTSTRAP_SERVERS_CONFIG -> s"localhost:$kafkaPort"
@@ -32,7 +24,6 @@ abstract class KafkaIntSpec extends BaseSpec with BeforeAndAfterAll with Patienc
 
   override def afterAll() = {
     kafkaAdminClient.close()
-    zkUtils.close()
     kafkaServer.close()
   }
 


### PR DESCRIPTION
Closes #55 

- https://github.com/cakesolutions/scala-kafka-client#testkit is no longer available anywhere since Bintray was deprecated.
- A [slightly newer forked version](https://github.com/Pirum-Systems/scala-kafka-client) has been published on maven central under `com.pirum`, so we can use this instead.
- Uses `kafka-clients` 2.4.1 in tests which no longer provides `ZkUtils`, so need to use the admin client for topic assertions.